### PR TITLE
fix: monitor background events GameController

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - uses: fwal/setup-swift@v1
+    - name: Get swift version
+      run: swift --version # Swift 5.5.2
     - uses: actions/checkout@v2
     - name: Build
       run: swift build -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: fwal/setup-swift@v1
-    - name: Get swift version
-      run: swift --version # Swift 5.5.2
     - uses: actions/checkout@v2
     - name: Build
       run: swift build -v

--- a/ds4macos.xcodeproj/project.pbxproj
+++ b/ds4macos.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = nl.dijkitech.ds4macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -504,7 +504,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = nl.dijkitech.ds4macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/ds4macos/ControllerService.swift
+++ b/ds4macos/ControllerService.swift
@@ -25,6 +25,11 @@ class ControllerService: ObservableObject {
     init(server: DSUServer, maximumControllerCount: Int = 4) {
         self.maximumControllerCount = maximumControllerCount
         self.server = server
+        
+        if #available(macOS 11.3, *) {
+            GCController.shouldMonitorBackgroundEvents = true
+        }
+        
         self.observeControllers()
     }
     


### PR DESCRIPTION
Since MacOS 11.3 the [default setting](https://developer.apple.com/documentation/gamecontroller/gccontroller/3738171-shouldmonitorbackgroundevents) for monitoring background events was set to false, with this PR it is re-enabled.

Fixes #7 